### PR TITLE
Lang params

### DIFF
--- a/python-main.js
+++ b/python-main.js
@@ -1362,6 +1362,7 @@ function web_editor(config) {
             $("#language_container").addClass('hidden');
             TRANSLATIONS.updateLang($(this).attr('id'), function(translations) {
                 config.translate = translations;
+            document.getElementsByTagName("HTML")[0].setAttribute("lang", lang);
             });
         });
 
@@ -1400,6 +1401,7 @@ function web_editor(config) {
                 TRANSLATIONS.updateLang(lang, function(translations) {
                     config.translate = translations;
                 });
+                document.getElementsByTagName("HTML")[0].setAttribute("lang", lang);
             }else{
             }
             }
@@ -1408,6 +1410,7 @@ function web_editor(config) {
                 TRANSLATIONS.updateLang(language, function(translations) {
                     config.translate = translations;
                 });
+                document.getElementsByTagName("HTML")[0].setAttribute("lang", language);
             }else{
             }
             }
@@ -1432,8 +1435,10 @@ function web_editor(config) {
     }
     
     function get_language_hash(){
-        var hash_statement = window.location.match(/#l.*/);
-        var languageExt = hash_statement.match(/=.*/).substr(1);
+        var hash_statement = window.location.href.match(/#l.*/);
+        if (hash_statement){    
+            var languageExt = hash_statement.match(/=.*/).substr(1);
+        }
         return languageExt;
         
     }


### PR DESCRIPTION
Fixed get_language_hash and updates lang attribute of html element when language is changed

The lang attribute of the html element is updated to match the language of the page whenever the language is changed by the URL on loading the page or when a user changes the language by button.

The get_language_hash function has been fixed. Before it was not searching the URL properly, and when there wasn't a hash it was crashing. Now it only tries to process the hash parameter if the hash parameter is not null.